### PR TITLE
Add automated tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,12 +21,18 @@ jobs:
         with:
           repository: gsingh93/linux-exploit-dev-env
 
+      # Don't clone submodules since we need to use the version of
+      # `art-kernel-toolkit` from the commit currently being tested
       - name: Clone build rules for art-kt
         uses: actions/checkout@v4
         with:
           repository: gsingh93/linux-exploit-dev-env-art-kt
-          submodules: true
           path: external/art-kt
+
+      - name: Clone art-kernel-toolkit
+        uses: actions/checkout@v4
+        with:
+          path: external/art-kt/art-kernel-toolkit
 
       - name: Download kernel artifacts
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,96 @@
+name: Build
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [arm64, x86_64]
+        kernel: [{ack: 0, version: 5.10.214}, {ack: 0, version: 5.15.153}, {ack: 0, version: 6.1.84}, {ack: 0, version: 6.6.25}, {ack: 1, version: android13-5.10-lts}, {ack: 1, version: android14-5.15-lts}]
+    env:
+      ACK: ${{ matrix.kernel.ack }}
+      ARCH: ${{ matrix.arch }}
+      ARTIFACTS_URL: https://github.com/gsingh93/linux-exploit-dev-env/releases/download/2024.04.07-ebc24a8
+      HEADERS_URL: https://github.com/gsingh93/linux-exploit-dev-env/releases/download/linux-headers-2024.04.07-ebc24a8
+    steps:
+
+      - name: Clone Linux Exploit Dev Environment
+        uses: actions/checkout@v4
+        with:
+          repository: gsingh93/linux-exploit-dev-env
+
+      - name: Clone build rules for art-kt
+        uses: actions/checkout@v4
+        with:
+          repository: gsingh93/linux-exploit-dev-env-art-kt
+          submodules: true
+          path: external/art-kt
+
+      - name: Download kernel artifacts
+        shell: bash
+        run: |
+          set -x
+
+          if [ $ACK -eq 0 ]; then
+            KERNEL_TYPE=linux
+          else
+            KERNEL_TYPE=ack
+          fi
+
+          if [ $ARCH == x86_64 ]; then
+            KERNEL_IMAGE_NAME=bzImage
+          elif [ $ARCH == arm64 ]; then
+            KERNEL_IMAGE_NAME=Image
+          fi
+
+          SUFFIX=${KERNEL_TYPE}-${{ matrix.kernel.version }}-${ARCH}
+
+          wget --no-verbose ${ARTIFACTS_URL}/${KERNEL_IMAGE_NAME}-${SUFFIX}
+          wget --no-verbose ${ARTIFACTS_URL}/alpine-${ARCH}.img
+          wget --no-verbose ${HEADERS_URL}/linux-headers-${SUFFIX}.deb
+
+          dpkg-deb -R linux-headers-${SUFFIX}.deb linux-headers
+
+          LINUX_OUT="$PWD/linux-headers/usr/src/linux-headers-*"
+
+          # The extra echo is to force glob expansion
+          echo "LINUX_OUT=$(echo $LINUX_OUT)" >> $GITHUB_ENV
+          echo "QEMU_KERNEL_IMAGE=$PWD/${KERNEL_IMAGE_NAME}-${SUFFIX}" >> $GITHUB_ENV
+          echo "ROOTFS=$PWD/alpine-${ARCH}.img" >> $GITHUB_ENV
+
+      - run: ls -lR
+
+      - name: Build art-kt
+        shell: bash
+        run: |
+          set -x
+
+          make $PWD/toolchain/clang
+
+          # LINUX_OUT is set in the environment
+          make art-kt
+
+      - run: ls -lR ${{ env.LINUX_OUT }}/modules_install
+
+      - name: Install testing dependencies
+        run: sudo apt update && sudo apt install -y qemu-system-x86 qemu-system-arm
+
+      - name: Test art-kt
+        shell: bash
+        run: |
+          set -x
+
+          MODULES_DIR=$LINUX_OUT/modules_install/lib/modules/*/
+
+          # Expand the glob
+          MODULES_DIR=$(echo $MODULES_DIR)
+
+          # The module won't load without `modules.dep`
+          echo "extra/art-kernel-toolkit.ko:" > $MODULES_DIR/modules.dep
+
+          # LINUX_OUT, ROOTFS, and QEMU_KERNEL_IMAGE are set in the environment
+          make art-kt_test | tee test.log
+
+          grep "All tests passed" test.log || exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
       ARCH: ${{ matrix.arch }}
       ARTIFACTS_URL: https://github.com/gsingh93/linux-exploit-dev-env/releases/download/2024.04.07-ebc24a8
       HEADERS_URL: https://github.com/gsingh93/linux-exploit-dev-env/releases/download/linux-headers-2024.04.07-ebc24a8
+      QEMU_RELEASE_URL: https://github.com/gsingh93/linux-exploit-dev-env/releases/download/qemu-8.2.2-94f421c94011baa837390074449cdd9811441c78
     steps:
 
       - name: Clone Linux Exploit Dev Environment
@@ -86,8 +87,28 @@ jobs:
 
       - run: ls -lR ${{ env.LINUX_OUT }}/modules_install
 
-      - name: Install testing dependencies
-        run: sudo apt update && sudo apt install -y qemu-system-x86 qemu-system-arm
+      - name: Download QEMU prebuilts
+        shell: bash
+        run: |
+          set -x
+
+          if [ $ARCH == x86_64 ]; then
+            QEMU_BIN=qemu-system-x86_64
+          elif [ $ARCH == arm64 ]; then
+            QEMU_BIN=qemu-system-aarch64
+          fi
+
+          wget --no-verbose ${QEMU_RELEASE_URL}/${QEMU_BIN}
+
+          chmod +x $QEMU_BIN
+
+          wget --no-verbose https://download.qemu.org/qemu-8.2.2.tar.xz
+          tar -xf qemu-8.2.2.tar.xz
+
+          echo "QEMU_BIN=$PWD/$QEMU_BIN" >> $GITHUB_ENV
+
+      - name: Install QEMU dependencies
+        run: sudo apt update && sudo apt install -y libfdt1
 
       - name: Test art-kt
         shell: bash
@@ -108,6 +129,6 @@ jobs:
           echo "${ART_KT_DIR}/art-kernel-toolkit.ko:" > $MODULES_DIR/modules.dep
 
           # LINUX_OUT, ROOTFS, and QEMU_KERNEL_IMAGE are set in the environment
-          make art-kt_test | tee test.log
+          QEMU_EXTRA_ARGS="-L qemu-8.2.2/pc-bios" make art-kt_test QEMU_BIN=$QEMU_BIN | tee test.log
 
           grep "All tests passed" test.log || exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,8 +93,13 @@ jobs:
           # Expand the glob
           MODULES_DIR=$(echo $MODULES_DIR)
 
-          # The module won't load without `modules.dep`
-          echo "extra/art-kernel-toolkit.ko:" > $MODULES_DIR/modules.dep
+          ART_KT_MOD=$(find $MODULES_DIR -name art-kernel-toolkit.ko)
+
+          # Get the directory the module is in i.e. `extra` or `updates`
+          ART_KT_DIR=$(basename $(dirname $ART_KT_MOD))
+
+          # `modprobe` won't work without `modules.dep`
+          echo "${ART_KT_DIR}/art-kernel-toolkit.ko:" > $MODULES_DIR/modules.dep
 
           # LINUX_OUT, ROOTFS, and QEMU_KERNEL_IMAGE are set in the environment
           make art-kt_test | tee test.log

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,12 @@ jobs:
 
       - run: ls -lR
 
+      - name: Get cached clang
+        uses: actions/cache@v4
+        with:
+          key: clang
+          path: toolchain/clang
+
       - name: Build art-kt
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Contributions are welcome, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 This is not an officially supported Google product.
 
----
+______________________________________________________________________
 
 - [Clone and Build](#clone-and-build)
 - [Installing](#installing)


### PR DESCRIPTION
Tests with 12 different kernels on every push/PR. Depends on https://github.com/gsingh93/linux-exploit-dev-env and https://github.com/gsingh93/linux-exploit-dev-env-art-kt.

- arm64 tests are failing because ubuntu-22.04 uses an older version of QEMU
- linux 5.10 tests are failing due to an upstream kernel bug, will be fixed in the next stable kernel release
- android13-5.10 and android14-5.15 tests are failing, and I'm not sure why. Need to investigate more